### PR TITLE
chore: added actions/labeler@v5 configs.

### DIFF
--- a/.github/config/labeler.yaml
+++ b/.github/config/labeler.yaml
@@ -1,0 +1,28 @@
+# File matches
+app(api):
+- changed-files:
+  - any-glob-to-any-file: ['api-server/**']
+
+app(ui):
+- changed-files:
+  - any-glob-to-any-file: ['web-frontend/**']
+
+ci:
+- changed-files:
+  - any-glob-to-any-file: ['.github/**/*']
+
+deps:
+- changed-files:
+  - any-glob-to-any-file: ['api-server/package.json', 'web-frontend/package.json']
+- head-branch: ['^dependabot/']
+
+docs:
+- changed-files:
+  - any-glob-to-any-file: ['**/*.md']
+
+# Branch name matches
+dependabot:
+- head-branch: ['^dependabot/']
+
+bugs:
+- head-branch: ['^fix/', '^hotfix/']

--- a/.github/workflows/pull-request-labeler.yaml
+++ b/.github/workflows/pull-request-labeler.yaml
@@ -1,0 +1,20 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true
+        configuration-path: .github/config/labeler.yaml


### PR DESCRIPTION
# Issue link
Closes #44 

# What does this PR do?
Added PR labeler configurations with v5 format

# What does not include in this PR?
e2e testings with labeler behaviors, since `action/labeler@v5` would be triggered when we newly raise PR, so we could not check it within this PR.