### PR TITLE
build(registry): uploaded cleanup policies of GAR.

### DIFF
--- a/.github/artifactRegistryCleanupPolicy.json
+++ b/.github/artifactRegistryCleanupPolicy.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "clean-untagged-older-than-7-days",
+    "action": {"type": "Delete"},
+    "condition": {
+      "tagState": "untagged",
+      "olderThan": "7d"
+    }
+  },
+  {
+    "name": "keep-last-2",
+    "action": {"type": "Keep"},
+    "mostRecentVersions": {
+      "keepCount": 2
+    }
+  }
+]


### PR DESCRIPTION
## Issue link
Relates: #60 

## What does this PR do?
Added cleanup policy JSON file of Google Artifact Registry

## What does not include in this PR?
e2e testings to confirm that retention policies will applied onto packages and the staled packages would be deleted in GAR.
