### PR TITLE
ci: refactor with upload-pages-artifact and deploy-pages.

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_deploy:
+  build:
     name: Build Vue app and Deploy
     runs-on: ubuntu-latest
     steps:
@@ -30,9 +30,22 @@ jobs:
         working-directory: ./web-frontend
           # Build vue app with outside of app-root
 
-      - name: Deploy to GitHub Pages to branch/gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Upload as artifacts for GitHub Pages
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./web-frontend/dist
+          retention-days: 3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages from artifacts
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Issue/PR link
relates: #108 

## What does this PR do?
- Removed `peaceiris/actions-gh-pages` with replacing GitHub official gh-actions

## What does not include in this PR?
- e2e testings, since this requires merge into `main` to confirm changes would be applied

## (Optional) Additional Contexts
N/A
