### PR TITLE
fix(ci): reverted bumped version and added permissions to pages

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -42,10 +42,11 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      actions: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy GitHub Pages from artifacts
         id: deployment
-        uses: actions/deploy-pages@v4.0.4
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Issue/PR link
relates: #108

## What does this PR do?
- Reverted #118, downgrading `actions/deploy-pages`
- Added permission of `action: read` (See https://github.com/hwakabh/hwakabh.github.io/issues/108#issuecomment-1936322853)

## What does not include in this PR?
- e2e testings, since this requires merge into `main` to confirm changes would be applied

## (Optional) Additional Contexts
N/A
