### PR TITLE
fix(build): separated npm-scripts for prod.

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon ./bin/www"
+    "dev": "nodemon ./bin/www",
+    "start": "node ./bin/www"
   },
   "engines": {
     "node": "18.16.0"


### PR DESCRIPTION
## Issue/PR link
relates: #178

## What does this PR do?
Describe what changes you make in your branch:
- separated npm-scripts for prod and local, since this breaks backend application startups, where deps of nodemon is defined as `devDependencies` (See https://github.com/hwakabh/hwakabh.github.io/issues/178#issuecomment-1962499777)

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied
