### PR TITLE
fix(ci): sytanx errors on dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -53,6 +53,7 @@ updates:
       - "ci"
     reviewers:
       - "hwakabh"
+    groups:
       non-majors:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## Issue/PR link
closes: #345 
relates: #347 

## What does this PR do?
Describe what changes you make in your branch:
- fixed syntax error of missing `groups` fields

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied
