### PR TITLE
feat(ui): added embedded iframe of Apple Music in Vue frontend

### DIFF
--- a/web-frontend/src/pages/About.vue
+++ b/web-frontend/src/pages/About.vue
@@ -32,7 +32,7 @@ axios.get('/api/v1/about/movies')
   </p>
   <h2 class="subsections">Musics</h2>
     <p>
-      Fetched from <a href="https://music.apple.com/jp/playlist/pl.u-xlyNEdkuA4ymPy">Personal Apple Music playlist</a>
+      Fetched from <a href="https://music.apple.com/jp/playlist/pl.u-xlyNEdkuA4ymPy" target="_blank" rel="noopener noreferrer">Personal Apple Music playlist</a>
     </p>
     <iframe
       allow="autoplay *; encrypted-media *;"
@@ -44,12 +44,12 @@ axios.get('/api/v1/about/movies')
     </iframe>
 
   <h2 class="subsections">Books</h2>
-    <p>Fetched from latest books in bookshelf from <a href="https://booklog.jp">booklog</a></p>
+    <p>Fetched from latest books in bookshelf API from <a href="https://booklog.jp/users/hwakabh" target="_blank" rel="noopener noreferrer">booklog</a></p>
     <li v-for="(b, idx) in bookData" :key="idx">
       {{ b }}
     </li>
   <h2 class="subsections">Movies</h2>
-    <p>Fetched from latest clips from <a href="https://filmarks.com">Filmarks</a></p>
+    <p>Fetched from latest clips from <a href="https://filmarks.com/users/11ne56"  target="_blank" rel="noopener noreferrer">Filmarks</a></p>
     <li v-for="(m, idx) in movieData" :key="idx">
       {{ m }}
     </li>

--- a/web-frontend/src/pages/About.vue
+++ b/web-frontend/src/pages/About.vue
@@ -32,8 +32,17 @@ axios.get('/api/v1/about/movies')
   </p>
   <h2 class="subsections">Musics</h2>
     <p>
-      TBD
+      Fetched from <a href="https://music.apple.com/jp/playlist/pl.u-xlyNEdkuA4ymPy">Personal Apple Music playlist</a>
     </p>
+    <iframe
+      allow="autoplay *; encrypted-media *;"
+      frameborder="0"
+      height="450"
+      style="width:100%;max-width:660px;overflow:hidden;background:transparent;"
+      sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+      src="https://embed.music.apple.com/jp/playlist/pl.u-xlyNEdkuA4ymPy">
+    </iframe>
+
   <h2 class="subsections">Books</h2>
     <p>Fetched from latest books in bookshelf from <a href="https://booklog.jp">booklog</a></p>
     <li v-for="(b, idx) in bookData" :key="idx">


### PR DESCRIPTION
## Issue/PR link
closes: #355 

## What does this PR do?
Describe what changes you make in your branch:
- added embedded iframe to UI for listing up songs in specific/personal playlist
- added `target="_blank"` and `ref="noopener noreferrer"` in each hyperlink

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the "Musics" section with a direct link to an Apple Music playlist and embedded player for improved interactivity.
	- Updated the "Books" section to clarify that the latest titles are pulled from a bookshelf API, providing accurate sourcing.
	- Improved the "Movies" section description to specify that clips are sourced from a particular Filmarks user, adding personalized context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->