### PR TITLE
fix(ci): allowed to pass RapidAPI key via GitHub Secret.

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   MAIL_API_KEY: ${{ secrets.MAIL_API_KEY }}
+  RAPID_API_KEY: ${{ secrets.RAPID_API_KEY }}
 
 jobs:
   image_build_and_push:
@@ -64,4 +65,4 @@ jobs:
           service: 'gh-pages-api-server'
           env_vars: |
             MAIL_API_KEY=${{ env.MAIL_API_KEY }}
-
+            RAPID_API_KEY=${{ env.RAPID_API_KEY }}


### PR DESCRIPTION
## Issue/PR link
closes: #357 

## What does this PR do?
Describe what changes you make in your branch:
- added RapidAPI key to GitHub Secret 
- enabled to fetch the key in CI and passed it to Cloud Run

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow capabilities by integrating the Rapid API service through a new environment variable, `RAPID_API_KEY`.
  
- **Chores**
	- Improved security and flexibility of the GitHub Actions workflow by utilizing repository secrets for API key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->