### PR TITLE
refactor: deprecated endpoint and UI contents

### DIFF
--- a/api-server/fixtures/payloads/publications.json5
+++ b/api-server/fixtures/payloads/publications.json5
@@ -3,7 +3,7 @@
   "list": [
     {
       title: 'VMware Explore 2022',
-      descriptions: 'Presentation of step-by-step automations of Kubernetes Operations',
+      descriptions: 'Presentation of step-by-step CI/CD pipeline design for Kubernetes Operations',
       date: '2022/11/16',
       filename: '20221116_VMware-Explore-2022-Japan_MA22278.pdf',
     },

--- a/api-server/fixtures/payloads/works.json5
+++ b/api-server/fixtures/payloads/works.json5
@@ -4,13 +4,13 @@
     {
       "title": "Bennu Official Homepage",
       "url": "https://bennu-official.page/home/",
-      "gitHubRepoUrl": "https://github.com/hwakabh/bennu-official",
+      "gitHubRepoUrl": "https://github.com/hwakabh/bennu-official.page",
       "descriptions": "Official Homepage of Bennu",
       "techStacks": [
         "Python",
         "Django",
-        "Kubernetes", "Google Kubernetes Engine",
-        "Cloud Native Builpacks", "Google Cloud Buildpacks",
+        "Kubernetes (Google Kubernetes Engine)",
+        "Cloud Native Builpacks (Google Cloud Buildpacks)",
       ],
     },
     {
@@ -27,21 +27,23 @@
     {
       "title": "6ow3idGirl",
       "url": "https://6ow3idgirl.com",
-      "gitHubRepoUrl": "https://github.com/hwakabh/6ow3idGirl",
+      "gitHubRepoUrl": "https://github.com/hwakabh/6ow3idGirl.com",
       "descriptions": "Official Homepage of 6ow 3id girl",
       "techStacks": [
         "Express",
+        "Next.js"
       ]
     },
     {
       "title": "waseda-mochida",
       "url": "",
-      "gitHubRepoUrl": "https://github.com/hwakabh/waseda-mochida",
+      "gitHubRepoUrl": "https://github.com/hwakabh/waseda-mochida.com",
       "descriptions": "Official Homepage of Waseda Mochida",
       "techStacks": [
         "Python",
         "Flask",
-        "LINE Pay"
+        "LINE Pay API",
+        "Heroku"
       ]
     },
     {
@@ -51,6 +53,7 @@
       "descriptions": "Luana Shanti Homepage hosted by WordPress",
       "techStacks": [
         "WordPress",
+        "CSS"
       ]
     },
   ]

--- a/api-server/routes/cv.js
+++ b/api-server/routes/cv.js
@@ -55,25 +55,6 @@ router.get('/educations', function(req, res, next) {
   });
 });
 
-router.get('/projects', async (req, res, next) => {
-  // #swagger.tags = ['CV']
-  // #swagger.summary = 'returns list of projects with static contents'
-  // #swagger.description = '/api/v1/cv/projects'
-  const projects = await axios.get(url)
-    .then(response => {
-      return response.data.projects
-    })
-    .catch(error => {
-      console.log(error);
-    })
-
-  res.header('Content-Type', 'application/json; charset=utf-8');
-  res.json({
-    "path": req.originalUrl,
-    "content": projects
-  });
-});
-
 router.get('/publications', function(req, res, next) {
   // #swagger.tags = ['CV']
   // #swagger.summary = 'returns list of publications with static contents'

--- a/schemas/swagger.json
+++ b/schemas/swagger.json
@@ -146,20 +146,6 @@
         }
       }
     },
-    "/api/v1/cv/projects": {
-      "get": {
-        "tags": [
-          "CV"
-        ],
-        "summary": "returns list of projects with static contents",
-        "description": "/api/v1/cv/projects",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/api/v1/cv/publications": {
       "get": {
         "tags": [

--- a/web-frontend/src/pages/Works.vue
+++ b/web-frontend/src/pages/Works.vue
@@ -35,6 +35,11 @@ onMounted(() => {
           <strong><a :href="w.url" target="_blank"> {{ w.title }} </a></strong>
           <br>
           {{ w.descriptions }}
+          <br>
+          <span v-for="(t, idx) in w.techStacks" :key="idx">
+            {{ t }}
+            <span v-if="idx+1 != w.techStacks.length"> / </span>
+          </span>
         </li>
       </ul>
 


### PR DESCRIPTION
## Issue/PR link
closes: #437

## What does this PR do?
Describe what changes you make in your branch:
- removed `/api/v1/cv/works` endpoint from backend API
- enabled to loop `techStacks` elements in `workData` from backend properly
- updated descriptions in fixture data of publication

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display of work details in the Works page, showcasing technology stacks for each work item.
  
- **Bug Fixes**
	- Updated descriptions in the publications to reflect a focus on CI/CD pipeline design.
  
- **Chores**
	- Removed the `/projects` endpoint from the API, simplifying the routing structure.
	- Updated GitHub repository URLs and technology stacks for several entries in the works data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->