### PR TITLE
fix(ci): replaced with proper options for number of minimal replica.

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           image: 'us-central1-docker.pkg.dev/hwakabh-dev/gh-pages/api:latest'
           service: 'gh-pages-api-server'
-          flags: '--min-instances=3'
+          flags: '--service-min-instances=3'
           env_vars: |
             MAIL_API_KEY=${{ env.MAIL_API_KEY }}
             RAPID_API_KEY=${{ env.RAPID_API_KEY }}


### PR DESCRIPTION
## Issue/PR link
closes: #454 
relates: #459 

## What does this PR do?
Describe what changes you make in your branch:
- updated options, since `--min-instances` will not assure replicas of Cloud Run instances, instead we need to use `--service-min-instances` flags.

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment configuration for backend services to improve instance management in Cloud Run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->