### PR TITLE
feat(ci): explicitly provided based ubuntu versions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build_and_test:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Vue app and Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   git_pr_release:
     name: git-pr-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/stele-issues.yaml
+++ b/.github/workflows/stele-issues.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/triage-issues.yaml
+++ b/.github/workflows/triage-issues.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   triage_issue:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/triage-pull-requests.yaml
+++ b/.github/workflows/triage-pull-requests.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   triage_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Issue/PR link
N/A

## What does this PR do?
Describe what changes you make in your branch:
- For suppressing the warning below, specified `ubuntu-24.04` in `runs-on` fields, instead of using `ubuntu-latest`
```log
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
```

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
	- Updated GitHub Actions workflow runners from `ubuntu-latest` to `ubuntu-24.04` across multiple workflow files
	- Removed commented-out code for pull request assignee configuration in `triage-pull-requests.yaml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->