### PR TITLE
fix: added squash options to git-pr-release-action.

### DIFF
--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Make release PR
         uses: bakunyo/git-pr-release-action@master
+        with:
+          args: '--squashed'
         env:
           TZ: "Asia/Tokyo"
           GITHUB_TOKEN: ${{ secrets.PAT_GIT_PR_RELEASE }}


### PR DESCRIPTION
## Issue/PR link
relates: #564 , #565 

## What does this PR do?
Describe what changes you make in your branch:
- added `--squashed` options as CLI args of `git-pr-release`, since it will not support squash-merged commits by default.

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the automated release process so that release pull requests now consolidate changes into a single squashed commit, streamlining the commit history for easier review and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->