### PR TITLE
feat: add GitHub Actions workflow for Dependabot auto-merge

### DIFF
--- a/.github/workflows/pr-auto-merge.yaml
+++ b/.github/workflows/pr-auto-merge.yaml
@@ -1,7 +1,6 @@
 name: Dependabot Automerge with delay
 
 on:
-  # PRが更新された時、または定期実行（念のため）
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Issue/PR link
Enabled auto-merge of PR when PR is passing 24 hours

## What does this PR do?
Describe what changes you make in your branch:

<!-- START pr-commits   please keep comment here to allow auto update -->

* feat: add GitHub Actions workflow for Dependabot auto-merge (059951a104dfbd867ad2e813d349dff184cbefbb)
* chore: clean up comment in PR auto-merge workflow (698d9dd0e5efc14d3e3b3bd508801fd1fac4ae58)

<!-- END pr-commits   please keep comment here to allow auto update -->

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- e2e testings are not included in this PR, since this requires merge into `main` to confirm changes would be applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage Dependabot pull requests: it checks Dependabot PRs on an hourly schedule and will auto-merge them once they are at least 24 hours old.
  * If a PR is not yet 24 hours old, the workflow logs its age and waits until the delay elapses before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->